### PR TITLE
Add support for custom PostgreSQL host-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An Ansible role for installing PostgreSQL.
 - `postgresql_port` - Port for PostgreSQL to bind to (default: `5432`)
 - `postgresql_data_directory` - Default data directory (default: `/var/lib/postgresql/{{ postgresql_version }}/main`)
 - `postgresql_log_min_duration_statement` - Minimum duration for logging slow queries (default: `-1`)
+- `postgresql_hba_mapping:` - A mapping of PostgreSQL host-based authentication rules
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main
 postgresql_log_min_duration_statement: -1
+postgresql_hba_mapping: []

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -6,6 +6,8 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
+  config.vm.network "forwarded_port", guest: 5432, host: 5432
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
     ansible.sudo = true

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,10 @@
 ---
 - hosts: all
+
+  vars:
+    postgresql_listen_addresses: "*"
+    postgresql_hba_mapping:
+      - { type: "host", database: "all", user: "all", address: "0.0.0.0/0", method: "md5" }
+
   roles:
     - { role: "azavea.postgresql" }

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -72,8 +72,9 @@
 # listen on a non-local interface via the listen_addresses
 # configuration parameter, or via the -i or -h command line switches.
 
-
-
+{% for rule in postgresql_hba_mapping %}
+{{ rule.type }} {{ rule.database }} {{ rule.user }} {{ rule.address }} {{ rule.method }}
+{% endfor %}
 
 # DO NOT DISABLE!
 # If you change this first entry you will need to make sure that the


### PR DESCRIPTION
This changeset adds support for custom PostgreSQL host-based authentication via Ansible variables. `postgresql_hba_mapping` is a list of maps that contain the following attributes:
- type
- database
- user
- address
- method

Inside a playbook, PostgreSQL HBA could be customized using:

```
vars:
  postgresql_listen_addresses: "*"
  postgresql_hba_mapping:
    - { type: "host", database: "all", user: "all", address: "0.0.0.0/0", method: "md5" }
```
