### PR TITLE
Add support for setting log_autovacuum_min_duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ An Ansible role for installing PostgreSQL.
 - `postgresql_listen_addresses` - Address for PostgreSQL to bind to (default: `localhost`)
 - `postgresql_port` - Port for PostgreSQL to bind to (default: `5432`)
 - `postgresql_data_directory` - Default data directory (default: `/var/lib/postgresql/{{ postgresql_version }}/main`)
-- `postgresql_log_min_duration_statement` - Minimum duration for logging slow queries (default: `-1`)
+- `postgresql_log_autovacuum_min_duration` - Minimum duration for logging long automatic vacuuming (default: `-1`)
+- `postgresql_log_min_duration_statement` - Minimum duration for logging long queries (default: `-1`)
 - `postgresql_hba_mapping:` - A mapping of PostgreSQL host-based authentication rules
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,6 @@ postgresql_package_version: "9.4.*-1.pgdg14.04+1"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main
+postgresql_log_autovacuum_min_duration: -1
 postgresql_log_min_duration_statement: -1
 postgresql_hba_mapping: []

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -471,7 +471,7 @@ stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_sta
 
 #autovacuum = on			# Enable autovacuum subprocess?  'on'
 					# requires track_counts to also be on.
-#log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
+log_autovacuum_min_duration = {{ postgresql_log_autovacuum_min_duration }}	# -1 disables, 0 logs all actions and
 					# their durations, > 0 logs only
 					# actions running at least this number
 					# of milliseconds.


### PR DESCRIPTION
This changeset adds an attribute for providing the `log_autovacuum_min_duration` PostgreSQL setting.