### PR TITLE
Add support for tuning work_mem and shared_buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ An Ansible role for installing PostgreSQL.
 - `postgresql_listen_addresses` - Address for PostgreSQL to bind to (default: `localhost`)
 - `postgresql_port` - Port for PostgreSQL to bind to (default: `5432`)
 - `postgresql_data_directory` - Default data directory (default: `/var/lib/postgresql/{{ postgresql_version }}/main`)
+- `postgresql_shared_buffers` - Memory for shared buffers (default: `128MB`)
+- `postgresql_work_mem` - Memory for worker processes (default: `4MB`)
 - `postgresql_log_autovacuum_min_duration` - Minimum duration for logging long automatic vacuuming (default: `-1`)
 - `postgresql_log_min_duration_statement` - Minimum duration for logging long queries (default: `-1`)
 - `postgresql_hba_mapping:` - A mapping of PostgreSQL host-based authentication rules

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ postgresql_package_version: "9.4.*-1.pgdg14.04+1"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main
+postgresql_shared_buffers: "128MB"
+postgresql_work_mem: "4MB"
 postgresql_log_autovacuum_min_duration: -1
 postgresql_log_min_duration_statement: -1
 postgresql_hba_mapping: []

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -113,7 +113,7 @@ ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'		# (change requires rest
 
 # - Memory -
 
-shared_buffers = 128MB			# min 128kB
+shared_buffers = {{ postgresql_shared_buffers }}			# min 128kB
 					# (change requires restart)
 #huge_pages = try			# on, off, or try
 					# (change requires restart)
@@ -124,7 +124,7 @@ shared_buffers = 128MB			# min 128kB
 # per transaction slot, plus lock space (see max_locks_per_transaction).
 # It is not advisable to set max_prepared_transactions nonzero unless you
 # actively intend to use prepared transactions.
-#work_mem = 4MB				# min 64kB
+work_mem = {{ postgresql_work_mem }}				# min 64kB
 #maintenance_work_mem = 64MB		# min 1MB
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB


### PR DESCRIPTION
This changeset simply allows role users to tweak the PostgreSQL `work_mem` and `shared_buffers` settings.