### PR TITLE
Add attribute for tuning max_connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An Ansible role for installing PostgreSQL.
 - `postgresql_listen_addresses` - Address for PostgreSQL to bind to (default: `localhost`)
 - `postgresql_port` - Port for PostgreSQL to bind to (default: `5432`)
 - `postgresql_data_directory` - Default data directory (default: `/var/lib/postgresql/{{ postgresql_version }}/main`)
+- `postgresql_max_connections` - Maximum number of connections (default: `100`)
 - `postgresql_shared_buffers` - Memory for shared buffers (default: `128MB`)
 - `postgresql_work_mem` - Memory for worker processes (default: `4MB`)
 - `postgresql_log_autovacuum_min_duration` - Minimum duration for logging long automatic vacuuming (default: `-1`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ postgresql_package_version: "9.4.*-1.pgdg14.04+1"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main
+postgresql_max_connections: 100
 postgresql_shared_buffers: "128MB"
 postgresql_work_mem: "4MB"
 postgresql_log_autovacuum_min_duration: -1

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -62,7 +62,7 @@ listen_addresses = '{{ postgresql_listen_addresses }}'
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 port = {{ postgresql_port }}	# (change requires restart)
-max_connections = 100			# (change requires restart)
+max_connections = {{ postgresql_max_connections }}			# (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3	# (change requires restart)


### PR DESCRIPTION
This changeset adds a attribute so that role users can tune the PostgreSQL `max_connections` setting.