### PR TITLE
Bump postgresql_package_version default to 9.4.*-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Ansible role for installing PostgreSQL.
 ## Role Variables
 
 - `postgresql_version` - PostgreSQL version (default: `9.4`)
-- `postgresql_package_version` - PostgreSQL package version (default: `"9.4.*-1.pgdg14.04+1`
+- `postgresql_package_version` - PostgreSQL package version (default: `"9.4.*-2.pgdg14.04+1`
 - `postgresql_listen_addresses` - Address for PostgreSQL to bind to (default: `localhost`)
 - `postgresql_port` - Port for PostgreSQL to bind to (default: `5432`)
 - `postgresql_data_directory` - Default data directory (default: `/var/lib/postgresql/{{ postgresql_version }}/main`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 postgresql_version: "9.4"
-postgresql_package_version: "9.4.*-1.pgdg14.04+1"
+postgresql_package_version: "9.4.*-2.pgdg14.04+1"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main


### PR DESCRIPTION
9.4.*-1 is no longer a valid value for the apt repo