### PR TITLE
Update default postgresql version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 postgresql_version: "9.6"
-postgresql_package_version: "9.6.*-1.pgdg14.04+1"
+postgresql_package_version: "9.6.*-2.pgdg14.04+1"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main


### PR DESCRIPTION
Upgrade the default version of the `postgresql-9.6` package to `9.6.*-2.pgdg14.04+1`.

# Testing 
- From the `examples/` directory, run `vagrant up --provision`.
- Ensure that `postgresql-9.6`, version `9.6.*-2.pgdg14.04+1` is installed. 
<pre>
<code>
vagrant ssh -c "apt-cache policy postgresql-9.6"
postgresql-9.6:
  <b>Installed: 9.6.1-2.pgdg14.04+1
  Candidate: 9.6.1-2.pgdg14.04+1</b>
  Version table:
 *** 9.6.1-2.pgdg14.04+1 0
        500 http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg/main amd64 Packages
        100 /var/lib/dpkg/status
</code>
</pre>

Connects #15 