### PR TITLE
Use default value of default_text_search_config

### DIFF
--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -564,7 +564,7 @@ lc_numeric = 'en_US.UTF-8'			# locale for number formatting
 lc_time = 'en_US.UTF-8'				# locale for time formatting
 
 # default configuration for text search
-default_text_search_config = 'pg_catalog.english'
+#default_text_search_config = 'pg_catalog.english'
 
 # - Other Defaults -
 


### PR DESCRIPTION
## Overview

This PR removes `default_text_search_config` from the `postgresql.conf.j2` template.

Resolves #18 

## Testing Instructions

I tested this by provisioning the [bee-pollinator](https://github.com/project-icp/bee-pollinator-app) services VM:

```
$ git clone https://github.com/project-icp/bee-pollinator-app
$ cd bee-pollinator-app
$ git checkout feature/jrb/test-ansible-postgresql
$ vagrant destroy -f ; vagrant up --provision services
```

Confirm that the value of `default_text_search_config` is `pg_catalog.simple`:

```bash
$ vagrant ssh
vagrant@services:~$ PGPASSWORD=icp psql -U icp -d icp -h localhost
psql (9.4.22)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

icp=# SHOW default_text_search_config;
 default_text_search_config
----------------------------
 pg_catalog.simple
(1 row)
```

See: https://github.com/project-icp/bee-pollinator-app/compare/feature/jrb/test-ansible-postgresql?expand=1