### PR TITLE
Feature/kak/upgrade ansible syntax#21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+- Update syntax for ansible 2.9.
+
 ## 1.0.0
 - Use default value of `default_text_search_config`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 postgresql_version: "9.6"
-postgresql_package_version: "9.6.*-2.pgdg14.04+1"
+postgresql_package_version: "9.6.*"
 postgresql_listen_addresses: localhost
 postgresql_port: 5432
 postgresql_data_directory: /var/lib/postgresql/{{ postgresql_version }}/main

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-18.04"
 
   config.vm.network "forwarded_port", guest: 5432, host: 5432
 

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -6,10 +6,10 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "bento/ubuntu-18.04"
 
-  config.vm.network "forwarded_port", guest: 5432, host: 5432
+  config.vm.network "forwarded_port", guest: 5432, host: 5433
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
-    ansible.sudo = true
+    ansible.become = true
   end
 end

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,11 +4,13 @@ galaxy_info:
   description: An Ansible role for installing PostgreSQL.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.8
+  min_ansible_version: 2.5
   platforms:
   - name: Ubuntu
     versions:
     - trusty
+    - xenial
+    - bionic
   categories:
   - database:sql
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,9 @@
                   state=present
 
 - name: Install PostgreSQL
-  apt: pkg={{ item }} state=present
-  with_items:
+  apt:
+    state: present
+    pkg:
     - postgresql-{{ postgresql_version }}={{ postgresql_package_version }}
     - postgresql-server-dev-{{ postgresql_version }}={{ postgresql_package_version }}
 

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -85,7 +85,7 @@
 # Database administrative login by Unix domain socket
 local   all             postgres                                peer
 
-{% if postgresql_version | version_compare('9.3', '<=') %}
+{% if postgresql_version is version('9.3', '<=') %}
 # Database administrative login from localhost
 host    all             postgres        127.0.0.1/32            trust
 {% endif %}

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -129,7 +129,7 @@ work_mem = {{ postgresql_work_mem }}				# min 64kB
 #replacement_sort_tuples = 150000	# limits use of replacement selection sort
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB
-{% if postgresql_version | version_compare('9.3', '>') %}
+{% if postgresql_version is version('9.3', '>') %}
 dynamic_shared_memory_type = posix	# the default is the first option
 					# supported by the operating system:
 					#   posix


### PR DESCRIPTION
Upgrade ansible syntax to fix provisioning failure on ansible 2.9+. Changes minimum ansible version to 2.5.

Fixes #21 
Fixes #20 